### PR TITLE
move peerDep check into activeAddonChildren

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -176,7 +176,11 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
 
   @Memoize()
   activeAddonChildren(pkg: Package = this.appPackage): AddonPackage[] {
-    let result = pkg.addonDependencies.filter(this.isActiveAddon) as AddonPackage[];
+    let result = (pkg.dependencies.filter(this.isActiveAddon) as AddonPackage[]).filter(
+      // When looking for child addons, we want to ignore 'peerDependencies' of a given package, to
+      // align with how ember-cli resolves addons
+      addon => !pkg.packageJSON.peerDependencies?.[addon.name]
+    );
     if (pkg === this.appPackage) {
       let extras = [this.synthVendor, this.synthStyles].filter(this.isActiveAddon) as AddonPackage[];
       result = [...result, ...extras];

--- a/packages/compat/src/moved-package-cache.ts
+++ b/packages/compat/src/moved-package-cache.ts
@@ -314,9 +314,6 @@ function packageProxy(pkg: Package, getMovedPackage: (pkg: Package) => Package) 
       if (prop === 'dependencies') {
         return pkg.dependencies.map(getMovedPackage);
       }
-      if (prop === 'addonDependencies') {
-        return pkg.addonDependencies.map(getMovedPackage);
-      }
       if (prop === 'nonResolvableDeps') {
         if (!pkg.nonResolvableDeps) {
           return pkg.nonResolvableDeps;

--- a/packages/shared-internals/src/package.ts
+++ b/packages/shared-internals/src/package.ts
@@ -167,22 +167,11 @@ export default class Package {
 
   @Memoize()
   get dependencies(): Package[] {
-    return this.loadDependencies(this.dependencyKeys);
-  }
-
-  @Memoize()
-  get addonDependencies(): Package[] {
-    // When looking for child addons, we want to ignore 'peerDependencies' of a given package, to
-    // align with how ember-cli resolves addons
-    return this.loadDependencies(this.dependencyKeys.filter(key => key !== 'peerDependencies'));
-  }
-
-  loadDependencies(keys: ('dependencies' | 'devDependencies' | 'peerDependencies')[]): Package[] {
-    const names = flatMap(keys, key => Object.keys(this.packageJSON[key] || {}));
+    let names = flatMap(this.dependencyKeys, key => Object.keys(this.packageJSON[key] || {}));
     return names
       .map(name => {
         if (this.nonResolvableDeps) {
-          const dep = this.nonResolvableDeps.get(name);
+          let dep = this.nonResolvableDeps.get(name);
           if (dep) {
             return dep;
           }


### PR DESCRIPTION
I'm suggesting this change on top of https://github.com/embroider-build/embroider/pull/728 because I'd rather keep this behavior local to child addon discovery and not make it be something that's part of the Package's API.

This should still provide the same performance benefit, because even though we will now examine the peerDeps before filtering them out, that work is guarded by the PackageCache and won't actually be repeated unnecessarily. The main thing we're trying to avoid is building many copies of each peerDep per consuming addon.